### PR TITLE
Fix asserts in Value::setComment

### DIFF
--- a/src/lib_json/json_value.cpp
+++ b/src/lib_json/json_value.cpp
@@ -1410,9 +1410,8 @@ void Value::setComment(String comment, CommentPlacement placement) {
     // Always discard trailing newline, to aid indentation.
     comment.pop_back();
   }
-  JSON_ASSERT(!comment.empty());
   JSON_ASSERT_MESSAGE(
-      comment[0] == '\0' || comment[0] == '/',
+      comment.empty() || comment[0] == '/',
       "in Json::Value::setComment(): Comments must start with /");
   comments_.set(placement, std::move(comment));
 }


### PR DESCRIPTION
The existing asserts seem to not be what was intended; they appear to have been mistranslated in pull/877.

The first assert for `comment.empty()` was previously a check that a provided `const char*` parameter was not null.  The function this replaced accepted empty strings, and the if() statement at the start of this function handles them.

The second assert for `comment[0] == '\0'` was written when `comment` was a `const char*`, and was testing for empty c-string input.  This PR replaces it with `comment.empty()` to match the original intent.